### PR TITLE
Lazy load API for model controller

### DIFF
--- a/src/Gemstone.Web/APIController/ReadOnlyModelController.cs
+++ b/src/Gemstone.Web/APIController/ReadOnlyModelController.cs
@@ -190,9 +190,11 @@ namespace Gemstone.Web.APIController
         /// <param name="token">Token associated with the query operation.</param>
         /// <param name="count">Maximum number of records to return. Defaults 1 record if not provided.</param>
         /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
-        /// <returns>An <see cref="IActionResult"/> containing the next set of records as <see cref="T:T[]"/>.</returns>
+        /// <returns>
+        /// An <see cref="IActionResult"/> containing the next set of records as <see cref="List{T}"/>.
+        /// </returns>
         /// <remarks>
-        /// When end of enumeration is reached, an empty array is returned.
+        /// When end of enumeration is reached, an empty result list is returned.
         /// </remarks>
         [HttpGet, Route("Next/{token}/{count:int?}")]
         public async Task<IActionResult> Next(string token, int? count, CancellationToken cancellationToken)
@@ -203,17 +205,17 @@ namespace Gemstone.Web.APIController
             if (!ConnectionCache.TryGet(token, out ConnectionCache? cache) || cache is null)
                 return NotFound();
 
-            if (cache.Records is null)
-                return Ok(Array.Empty<T>());
-
             List<T?> records = [];
 
-            for (int i = 0; i < (count ?? 1); i++)
+            if (cache.Records is not null)
             {
-                if (!await cache.Records.MoveNextAsync(cancellationToken).ConfigureAwait(false))
-                    break;
+                for (int i = 0; i < (count ?? 1); i++)
+                {
+                    if (!await cache.Records.MoveNextAsync(cancellationToken).ConfigureAwait(false))
+                        break;
 
-                records.Add(cache.Records.Current);
+                    records.Add(cache.Records.Current);
+                }
             }
 
             return Ok(records);

--- a/src/Gemstone.Web/APIController/ReadOnlyModelController.cs
+++ b/src/Gemstone.Web/APIController/ReadOnlyModelController.cs
@@ -208,7 +208,7 @@ namespace Gemstone.Web.APIController
 
             List<T?> records = [];
 
-            for (int i = 0; i < count; i++)
+            for (int i = 0; i < (count ?? 1); i++)
             {
                 if (!await cache.Records.MoveNextAsync(cancellationToken).ConfigureAwait(false))
                     break;

--- a/src/Gemstone.Web/APIController/ReadOnlyModelController.cs
+++ b/src/Gemstone.Web/APIController/ReadOnlyModelController.cs
@@ -171,7 +171,7 @@ namespace Gemstone.Web.APIController
         /// <param name="expiration">Expiration time for the query data, in minutes, if not accessed. Defaults to 1 minute if not provided.</param>
         /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
         /// <returns>An <see cref="IActionResult"/> containing a token to be used for subsequent requests.</returns>
-        [HttpGet, Route("Open/{filterExpression}/{parameters}/{expiration?}")]
+        [HttpGet, Route("Open/{filterExpression}/{parameters}/{expiration:double?}")]
         public Task<IActionResult> Open(string? filterExpression, object?[] parameters, double? expiration, CancellationToken cancellationToken)
         {
             if (!GetAuthCheck())
@@ -194,7 +194,7 @@ namespace Gemstone.Web.APIController
         /// <remarks>
         /// When end of enumeration is reached, an empty array is returned.
         /// </remarks>
-        [HttpGet, Route("Next/{token}/{count?}")]
+        [HttpGet, Route("Next/{token}/{count:int?}")]
         public async Task<IActionResult> Next(string token, int? count, CancellationToken cancellationToken)
         {
             if (!GetAuthCheck())


### PR DESCRIPTION
For consideration:

This builds on Async model operations branch, adding API operations for `Open` / `Next` / `Close` to the model controller to allow for huge data queries, read on demand, provided in small data sets. This prevents all data from being loaded into memory, it is delivered, record by record, as needed from the database.

These may be handy to have around for future need, even if not immediately used.

> You might argue that the existing calls do something similar with pagination, however, it does not appear that the `AdoDataConnection.PrimaryKeyCache` is persisted between calls on the existing model operations. That means every query first establishes a new primary key cache, basically loading _all_ records (primary keys only) in desired sort order with filtering applied, then skipping to the desired "page" of primary keys, before loading a page of records with all values. This will be expensive and slow on a large table.