### PR TITLE
Adopt ExpressionTableOperations for value-expression-backed model operations

### DIFF
--- a/src/Gemstone.Web/APIController/ModelController.cs
+++ b/src/Gemstone.Web/APIController/ModelController.cs
@@ -23,7 +23,6 @@
 // ReSharper disable StaticMemberInGenericType
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Gemstone.Data;

--- a/src/Gemstone.Web/APIController/ModelController.cs
+++ b/src/Gemstone.Web/APIController/ModelController.cs
@@ -72,7 +72,7 @@ namespace Gemstone.Web.APIController
         public virtual async Task<IActionResult> Post([FromBody]T record, CancellationToken cancellationToken)
         {
             await using AdoDataConnection connection = CreateConnection();
-            TableOperations<T> tableOperations = new(connection);
+            ExpressionTableOperations<T> tableOperations = new(connection);
             await tableOperations.AddNewRecordAsync(record, cancellationToken);
             T? foundRecord = await tableOperations.QueryRecordAsync(tableOperations.GetNonPrimaryFieldRecordRestriction(record, DefaultExcludedFields), cancellationToken).ConfigureAwait(false);
 

--- a/src/Gemstone.Web/WebExtensions.cs
+++ b/src/Gemstone.Web/WebExtensions.cs
@@ -33,7 +33,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Primitives;
 
 namespace Gemstone.Web
 {


### PR DESCRIPTION
## Summary

Consumer-side update for the `TableOperations<T>` refactor in `Gemstone.Data`. The base `TableOperations<T>` is now a pure POCO operator that honors only `[DefaultValue]`; evaluation of attribute-based value expressions (`DefaultValueExpressionAttribute` / `UpdateValueExpressionAttribute`) is now opt-in via the new `ExpressionTableOperations<T>`.

## Changes

- `ModelController.Post` now constructs `ExpressionTableOperations<T>` so create operations continue to evaluate model value expressions exactly as before.
- `SecureTableOperations<T>` (in `Gemstone.Data`) already wraps the expression variant, so the `ReadOnlyModelController` / `ModelController` secure paths are unchanged in behavior.

## Verification

- `Gemstone.Web` builds clean (0 errors) against the local `Gemstone.Data` project reference (Development configuration).

## Related PRs

- gemstone/data#37 — core `TableOperations<T>` refactor (required by this change)
- gemstone/timeseries#63 — sibling consumer update in timeseries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
