### PR TITLE
Avoid preview language features in the authentication web builder

### DIFF
--- a/src/Gemstone.Web/Security/IAuthenticationWebBuilder.cs
+++ b/src/Gemstone.Web/Security/IAuthenticationWebBuilder.cs
@@ -336,11 +336,14 @@ public static class AuthenticationWebBuilderExtensions
             .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
             .AddNegotiate("windows", options =>
             {
-                options.Events?.OnAuthenticated = context =>
+                if (options.Events is not null)
                 {
-                    AddProviderIdentityClaim(context.Principal, WindowsAuthenticationProviderExtensions.DefaultIdentity);
-                    return Task.CompletedTask;
-                };
+                    options.Events.OnAuthenticated = context =>
+                    {
+                        AddProviderIdentityClaim(context.Principal, WindowsAuthenticationProviderExtensions.DefaultIdentity);
+                        return Task.CompletedTask;
+                    };
+                }
             }).AddCookie();
     }
 


### PR DESCRIPTION
Avoids the following error when compiling using Visual Studio 2022.

> 5>C:\Projects\gemstone\web\src\Gemstone.Web\Security\IAuthenticationWebBuilder.cs(339,49,339,50): error CS8652: The feature 'null conditional assignment' is currently in Preview and unsupported. To use Preview features, use the 'preview' language version.